### PR TITLE
Refactor Product model to use the Item model

### DIFF
--- a/api/models/item_model.go
+++ b/api/models/item_model.go
@@ -1,0 +1,150 @@
+package models
+
+import (
+	"fmt"
+	"errors"
+	//"net/url"
+	"encoding/json"
+
+	"github.com/berryhill/gf-api/api/db"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+
+type Item struct {
+	ProductId		*bson.ObjectId          `json:"product_id"`
+	Active			bool          			`json:"active"`
+	Url 			string        			`json:"url"`
+	Image 			string        			`json:"image"`
+	Type 			string        			`json:"type"`
+	Brand			string        			`json:"brand"`
+	Name 			string        			`json:"name"`
+	Title			string                	`json:"title"`
+	Price 			string        			`json:"price"`
+	Retailer		string                  `json:"retailer"`
+	Details			[]string				`json:"details"`
+	Managed			bool                	`json:"managed"`
+}
+
+func NewItem() *Item {
+
+	i := new(Item)
+	item_id := bson.NewObjectId()
+	i.ProductId = &item_id
+	i.Active = true
+	i.Managed = false
+
+	return i
+}
+
+
+func (i *Item) Create(db_col string) error {
+
+	session := db.Session.Clone()
+	defer session.Close()
+
+	collection := session.DB("test").C(db_col)
+
+	err := collection.Insert(i)
+	if err != nil {
+		errors.New("Error inserting product into DB")
+	}
+
+	return err
+}
+
+func (i *Item) MarshalJson() ([]byte, error) {
+
+	json, _ := json.Marshal(i)
+
+	return json, nil
+}
+
+
+func (i *Item) Handle(
+	name string, title string, brand string, url string, db_col string) (
+	found bool, err error) {
+
+	// TODO: Improve product validation with details
+
+	session := db.Session.Clone()
+	defer session.Close()
+
+	collection := session.DB("test").C(db_col)
+
+	found = false; result := Product{}
+	err = collection.Find(bson.M{
+		"title": title,
+		"brand": brand,
+		"url": url}).One(&result)
+
+	// TODO: Need to compare error to "not found"
+
+	if err != nil {
+		found = true
+		i.Create(db_col)
+	} else {
+		i.Print()
+	}
+
+	return found, err
+}
+
+func (i *Item) Print() {
+
+	if i.Name == "" {
+		return
+	}
+
+	fmt.Println(i.Name)
+	fmt.Println(i.Brand)
+	fmt.Println(i.Type)
+	fmt.Println(i.Price)
+	fmt.Println(i.Active)
+	fmt.Println(i.Url)
+	fmt.Println(i.Image)
+	fmt.Println()
+}
+
+//func GetProducts(
+//	product string, query_params url.Values, page int, per_page int) (
+//	products []*Product, err error) {
+//
+//	// TODO: Implement a product collection to check if product exists
+//	// TODO: Implement kabab case in the URI.. currently '../fly_rods'
+//
+//
+//	session := db.Session.Clone()
+//	defer session.Close()
+//
+//	collection := session.DB("test").C(product)
+//
+//	params_exist := false
+//	for _ = range query_params {
+//		params_exist = true
+//	}
+//
+//	//collection.Find(bson.M{"abc": &bson.RegEx{Pattern: "efg", Options: "i"}})
+//
+//	if params_exist {
+//		for key, value := range query_params {
+//			if key == "search" {
+//				fmt.Println(value[0])
+//				err = collection.Find(
+//					bson.M{
+//						"$text": bson.M{"$search": value[0]}}).All(&products)
+//				if err != nil {
+//					// TODO: Log error
+//				}
+//			}
+//		}
+//	} else {
+//		err = collection.Find(nil).All(&products)
+//		if err != nil {
+//			// TODO: Log error
+//		}
+//	}
+//
+//	return products, err
+//}

--- a/api/scrapers/backcountry_scaper.go
+++ b/api/scrapers/backcountry_scaper.go
@@ -34,17 +34,17 @@ func NewBackcountryScraper() *BackcountryScraper {
 }
 
 func (bc *BackcountryScraper) getBrand(
-	item *goquery.Selection) (brand string, err error) {
+	scraped *goquery.Selection) (brand string, err error) {
 
-	brand = item.Find(".ui-pl-name-brand.qa-brand-name").Text()
+	brand = scraped.Find(".ui-pl-name-brand.qa-brand-name").Text()
 
 	return brand, nil
 }
 
 func (bc *BackcountryScraper) getName(
-	item *goquery.Selection) (name string, err error) {
+	scraped *goquery.Selection) (name string, err error) {
 
-	name = item.Find(".ui-pl-name-title").Text()
+	name = scraped.Find(".ui-pl-name-title").Text()
 	string_array := strings.Split(name, " ")
 
 	var actual_name bytes.Buffer
@@ -65,17 +65,17 @@ func (bc *BackcountryScraper) getName(
 }
 
 func (bc *BackcountryScraper) getTitle(
-	item *goquery.Selection) (title string, err error) {
+	scraped *goquery.Selection) (title string, err error) {
 
-	title = item.Find(".ui-pl-name-title").Text()
+	title = scraped.Find(".ui-pl-name-title").Text()
 
 	return title, nil
 }
 
 func (bc *BackcountryScraper) getPrice(
-	item *goquery.Selection) (price string, err error) {
+	scraped *goquery.Selection) (price string, err error) {
 
-	price_html := item.Find(".ui-pl-pricing-low-price")
+	price_html := scraped.Find(".ui-pl-pricing-low-price")
 	if price_html.Text() != "" {
 		price = price_html.Text()
 	} else {
@@ -87,10 +87,10 @@ func (bc *BackcountryScraper) getPrice(
 }
 
 func (bc *BackcountryScraper) getUrl(
-	item *goquery.Selection) (href string, err error) {
+	scraped *goquery.Selection) (href string, err error) {
 
 	var ok bool
-	item.Find("a").Each(func(_ int, link *goquery.Selection) {
+	scraped.Find("a").Each(func(_ int, link *goquery.Selection) {
 		href, ok = link.Attr("href")
 	})
 	if ok {
@@ -102,10 +102,10 @@ func (bc *BackcountryScraper) getUrl(
 }
 
 func (bc *BackcountryScraper) getImg(
-	item *goquery.Selection) (img string, err error) {
+	scraped *goquery.Selection) (img string, err error) {
 
 	var ok bool
-	item.Find("img").Each(func(_ int, link *goquery.Selection) {
+	scraped.Find("img").Each(func(_ int, link *goquery.Selection) {
 		img, ok = link.Attr("data-src")
 		if img == "" {
 			img , ok = link.Attr("src")
@@ -120,9 +120,9 @@ func (bc *BackcountryScraper) getImg(
 }
 
 func (bc *BackcountryScraper) getDetails(
-	item *goquery.Selection) (details []string, err error) {
+	scraped *goquery.Selection) (details []string, err error) {
 
-	name := item.Find(".ui-pl-name-title").Text()
+	name := scraped.Find(".ui-pl-name-title").Text()
 	string_array := strings.Split(name, " - ")
 
 	if len(string_array) > 1 {
@@ -164,27 +164,27 @@ func (bc *BackcountryScraper) Scrape() (
 				doc, _ = goquery.NewDocument(bc.Retailer.BaseUrl + url)
 			}
 			selection := doc.Find(".product")
-			selection.Each(func(i int, item *goquery.Selection) {
-				product := models.NewProduct()
-				product.Type = product_type
-				product.Brand, _ = bc.getBrand(item)
-				product.Name, _ = bc.getName(item)
-				product.Title, _ = bc.getTitle(item)
-				product.Price, _ = bc.getPrice(item)
-				product.Url, _ = bc.getUrl(item)
-				product.Retailer = bc.Retailer.Name
+			selection.Each(func(i int, scraped *goquery.Selection) {
+				item := models.NewItem()
+				item.Type = product_type
+				item.Brand, _ = bc.getBrand(scraped)
+				item.Name, _ = bc.getName(scraped)
+				item.Title, _ = bc.getTitle(scraped)
+				item.Price, _ = bc.getPrice(scraped)
+				item.Url, _ = bc.getUrl(scraped)
+				item.Retailer = bc.Retailer.Name
 
-				product.Image, err = bc.getImg(item)
+				item.Image, err = bc.getImg(scraped)
 				err = errors.New("New Error")
 				if err != nil {
 					errs = append(errs, err)
 				}
 
-				product.Details, _ = bc.getDetails(item)
+				item.Details, _ = bc.getDetails(scraped)
 
-				found, _ := product.Handle(
-					product.Name, product.Title, product.Brand, product.Url,
-					product_type)
+				found, _ := item.Handle(
+					item.Name, item.Title, item.Brand, item.Url,
+					"items")
 				if found {
 					//products = append(products, product)
 					item_added++

--- a/api/scrapers/cabelas_scaper.go
+++ b/api/scrapers/cabelas_scaper.go
@@ -43,9 +43,9 @@ func NewCabelasScraper() *CabelasScraper {
 }
 
 func (cb *CabelasScraper) getBrand(
-	item *goquery.Selection) (brand string, err error) {
+	scraped *goquery.Selection) (brand string, err error) {
 
-	title := item.Find(
+	title := scraped.Find(
 		".productContentBlock").Find(
 		"a").Find("h3").Text()
 
@@ -55,9 +55,9 @@ func (cb *CabelasScraper) getBrand(
 }
 
 func (cb *CabelasScraper) getName(
-	item *goquery.Selection) (name string, err error) {
+	scraped *goquery.Selection) (name string, err error) {
 
-	name = item.Find(
+	name = scraped.Find(
 		".productContentBlock").Find(
 		"a").Find("h3").Text()
 
@@ -65,9 +65,9 @@ func (cb *CabelasScraper) getName(
 }
 
 func (cb *CabelasScraper) getTitle(
-	item *goquery.Selection) (title string, err error) {
+	scraped *goquery.Selection) (title string, err error) {
 
-	title = item.Find(
+	title = scraped.Find(
 		".productContentBlock").Find(
 		"a").Find("h3").Text()
 
@@ -75,9 +75,9 @@ func (cb *CabelasScraper) getTitle(
 }
 
 func (cb *CabelasScraper) getPrice(
-	item *goquery.Selection) (price string, err error) {
+	scraped *goquery.Selection) (price string, err error) {
 
-	price = item.Find(
+	price = scraped.Find(
 		".pricingBlock").Find(".itemPrice").Text()
 
 	price_formatted := ""
@@ -91,10 +91,10 @@ func (cb *CabelasScraper) getPrice(
 }
 
 func (cb *CabelasScraper) getUrl(
-	item *goquery.Selection) (href string, err error) {
+	scraped *goquery.Selection) (href string, err error) {
 
 	var ok bool
-	item.Find(
+	scraped.Find(
 		".imageBlock").Find(
 		"a").Each(func(_ int, link *goquery.Selection) {
 
@@ -109,10 +109,10 @@ func (cb *CabelasScraper) getUrl(
 }
 
 func (cb *CabelasScraper) getImg(
-	item *goquery.Selection) (img string, err error) {
+	scraped *goquery.Selection) (img string, err error) {
 
 	var ok bool
-	item.Find(
+	scraped.Find(
 		".imageBlock").Find(
 		"a").Find(
 		"img").Each(func(_ int, link *goquery.Selection) {
@@ -128,9 +128,9 @@ func (cb *CabelasScraper) getImg(
 }
 
 func (cb *CabelasScraper) getDetails(
-	item *goquery.Selection) (details []string, err error) {
+	scraped *goquery.Selection) (details []string, err error) {
 
-	name := item.Find(".ui-pl-name-title").Text()
+	name := scraped.Find(".ui-pl-name-title").Text()
 	string_array := strings.Split(name, " - ")
 
 	if len(string_array) > 1 {
@@ -179,27 +179,27 @@ func (cb *CabelasScraper) Scrape() (response map[string]int, errs []error) {
 				doc, _ = goquery.NewDocument(url)
 			}
 			selection := doc.Find(".productItem")
-			selection.Each(func(i int, item *goquery.Selection) {
-				product := models.NewProduct()
-				product.Type = product_type
-				product.Brand, _ = cb.getBrand(item)
-				product.Name, _ = cb.getName(item)
-				product.Title, _ = cb.getTitle(item)
-				product.Price, _ = cb.getPrice(item)
-				product.Url, _ = cb.getUrl(item)
-				product.Retailer = cb.Retailer.Name
+			selection.Each(func(i int, scraped *goquery.Selection) {
+				item := models.NewItem()
+				item.Type = product_type
+				item.Brand, _ = cb.getBrand(scraped)
+				item.Name, _ = cb.getName(scraped)
+				item.Title, _ = cb.getTitle(scraped)
+				item.Price, _ = cb.getPrice(scraped)
+				item.Url, _ = cb.getUrl(scraped)
+				item.Retailer = cb.Retailer.Name
 
-				product.Image, err = cb.getImg(item)
+				item.Image, err = cb.getImg(scraped)
 				err = errors.New("New Error")
 				if err != nil {
 					errs = append(errs, err)
 				}
 
-				product.Details, _ = cb.getDetails(item)
+				item.Details, _ = cb.getDetails(scraped)
 
-				found, _ := product.Handle(
-					product.Name, product.Title, product.Brand, product.Url,
-					product_type)
+				found, _ := item.Handle(
+					item.Name, item.Title, item.Brand, item.Url,
+					"items")
 				if found {
 					//products = append(products, product)
 					item_added++

--- a/api/server/products.go
+++ b/api/server/products.go
@@ -28,8 +28,6 @@ func GetProducts(c echo.Context) error {
 	products, _ := models.GetProducts(product, c.QueryParams(), page, per_page)
 	var products_paginated []*models.Product
 
-	// TODO: Fix internal server error when page is out of range
-	// TODO: Implement total pages metadata
 	// TODO: Implement full text search
 	// TODO: Implement full substring search
 


### PR DESCRIPTION
In this PR, we implemented the Item model to replace the Product model. The product model will then be refactored to conglomerate Items and parse the best priced item to be used to populate the products on the website.