### PR TITLE
Implement POST/retailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Find the front end [here](https://github.com/berryhill/gf-frontend)
     + *Refactor product model to compose item models*
     + Implement algorithms to choose best item
 + CMS
-    + **CMS admin user .jwt architecture**
+    + *CMS admin user .jwt architecture*
     + *restricted CMS endpoints*
+        + **POST/retailer**
 + Filters
     + Endpoints
     + Query params

--- a/api/main.go
+++ b/api/main.go
@@ -16,15 +16,6 @@ func main() {
 	db.Connect()
 	server.SetupScrapers()
 
-	 //retailer := models.NewRetailer(
-	 //	"cabelas",
-	 //	"https://www.cabelas.com",
-	 //	"http://www.cabelas.com/catalog/browse/_/" +
-		//	"N-1104841?CQ_view=list&CQ_ztype=GNP&CQ_pagesize=40",
-	 //	"fly_rods",
-	 //)
-	 //retailer.Create()
-
 	e := echo.New()
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
@@ -34,9 +25,13 @@ func main() {
 		AllowMethods: []string{echo.GET, echo.PUT, echo.POST, echo.DELETE},
 	}))
 
+	// CMS Endpoints
 	e.POST("/backcountry/scrape", server.ScrapeBackcountry)
 	e.POST("/cabelas/scrape", server.ScrapeCabelas)
 
+	e.POST("/retailer", server.CreateRetailer)
+
+	// Frontend Endpoints
 	e.GET("/product-types", server.GetProductTypes)
 
 	e.GET("/products/:product", server.GetProducts)

--- a/api/models/retailer_model.go
+++ b/api/models/retailer_model.go
@@ -13,7 +13,7 @@ import (
 type Retailer struct {
 	Name 			string           	`json:"name"`
 	BaseUrl			string        		`json:"base_url"`
-	Products		map[string]string   `json:"product_urls"`
+	Products		map[string]string   `json:"products"`
 }
 
 func NewRetailer(

--- a/api/server/retailers.go
+++ b/api/server/retailers.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"github.com/berryhill/gf-api/api/models"
+
+	"github.com/labstack/echo"
+	"net/http"
+)
+
+
+func CreateRetailer(c echo.Context) error {
+
+	retailer := &models.Retailer{}
+
+	if err := c.Bind(retailer); err != nil {
+		return c.JSON(http.StatusBadRequest, err)
+	}
+
+	if err := retailer.Create(); err != nil {
+		return c.JSON(http.StatusInternalServerError, err)
+	}
+
+	return c.JSON(http.StatusCreated, retailer)
+}
+
+

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -46,6 +46,40 @@ $ curl http://localhost:8080/products/fly_rods
 }
 ```
 
+### POST/retailer
+
+#### Request Payload
+```
+{
+    "name": {string},
+    "base_url": {string},
+    "products": {
+        {string}: {string},
+        ...
+    }
+}
+```
+
+ex:
+
+```
+$ curl -d '{"name":"smapler", "base_url":"s.com", "products": {"sample": "/sample"}}' \
+    -H "Content-Type: application/json" \
+    -X POST http://localhost:8080/retailer
+```
+
+#### Response
+```
+{
+    "name": {string},
+    "base_url": {string},
+    "products": {
+        {string}: {string},
+        ...
+    }
+}
+```
+
 ### POST/:scraper/scrape
 
 ex:


### PR DESCRIPTION
Here we implemented the POST/retailer endpoint. Below is an example.

```
$ curl -d '{"name":"smapler", "base_url":"s.com", "products": {"sample": "/sample"}}' \
    -H "Content-Type: application/json" \
    -X POST http://localhost:8080/retailer
```

https://github.com/berryhill/gf-api/blob/master/docs/api-spec.md#postretailer